### PR TITLE
Correct ruby example smtp address to smtp.mailgun.org

### DIFF
--- a/source/samples/smtp-send-simple-message.rst
+++ b/source/samples/smtp-send-simple-message.rst
@@ -108,7 +108,7 @@
   Mail.defaults do
     delivery_method :smtp, {
       :port      => 587,
-      :address   => "smtp.mailgun.com",
+      :address   => "smtp.mailgun.org",
       :user_name => "",
       :password  => "",
     }


### PR DESCRIPTION
Original referenced smtp.mailgun.com which caused SSL errors as the certificate is signed for *.mailgun.org